### PR TITLE
Add mock API and demo fetch button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+frontend/node_modules/
+frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ Demo frontend for a voice-first chat that morphs between a speaking circle and r
 The interface starts as a black‑and‑white circle that animates with the model’s voice. When the model issues a `render` message with a `ClassCardGrid`, the circle transforms into the cards and retracts once the conversation moves on.
 
 Connection status and activity logs are printed to the browser console, and a small status label shows the current WebRTC state (`connecting`, `connected`, `disconnected`, or `failed`).
+
+### Mock API
+
+If the OpenAI realtime service is unavailable, you can launch a small mock API that returns sample card data:
+
+```bash
+cd frontend
+npm run mock-api
+```
+
+Then open the frontend and press **Cargar tarjetas de prueba** to fetch the sample cards.
+

--- a/frontend/mock-api.js
+++ b/frontend/mock-api.js
@@ -1,0 +1,28 @@
+import { createServer } from 'http';
+
+const cards = {
+  component: 'ClassCardGrid',
+  props: {
+    date: '2024-06-01',
+    gym: 'Downtown Gym',
+    items: [
+      { id: '1', title: 'Yoga', start: '09:00', coach: 'Alice', spots: 5 },
+      { id: '2', title: 'Pilates', start: '10:30', coach: 'Bob', spots: 3 }
+    ]
+  }
+};
+
+const server = createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/cards') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(cards));
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = 3001;
+server.listen(PORT, () => {
+  console.log(`Mock API listening on http://localhost:${PORT}`);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo 'No tests'"
+    "test": "echo 'No tests'",
+    "mock-api": "node mock-api.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -69,6 +69,17 @@ export default function App() {
     }
   }, [renderPayload]);
 
+  async function fetchCards() {
+    try {
+      const res = await fetch('http://localhost:3001/cards');
+      if (!res.ok) throw new Error('failed to load cards');
+      const payload = await res.json();
+      setRenderPayload(payload);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   function monitorAudio(stream) {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
     const src = ctx.createMediaStreamSource(stream);
@@ -97,6 +108,7 @@ export default function App() {
         <audio ref={remoteRef} autoPlay />
         {renderPayload && <RenderHost payload={renderPayload} />}
       </div>
+      <button onClick={fetchCards}>Cargar tarjetas de prueba</button>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- create a tiny HTTP server that returns mock `ClassCardGrid` data
- add button in the React app that fetches from the mock API
- document how to run the mock API and ignore node_modules

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898cd2d28e883309d6fb134ce287adb