### PR TITLE
Add env-based OpenAI config and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Demo frontend for a voice-first chat that morphs between a speaking circle and r
    cd frontend
    npm install
    ```
-2. Provide your OpenAI key as `VITE_OAI_KEY` in an `.env.local` file.
+2. Copy `.env.example` to `.env.local` and set:
+   ```bash
+   VITE_OAI_KEY=<your-openai-key>
+   VITE_OAI_ENDPOINT=https://api.openai.com/v1/realtime
+   VITE_OAI_MODEL=gpt-4o-realtime-preview
+   ```
 3. Start the dev server:
    ```bash
    npm run dev

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_OAI_KEY=sk-...
+VITE_OAI_ENDPOINT=https://api.openai.com/v1/realtime
+VITE_OAI_MODEL=gpt-4o-realtime-preview

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,10 +42,24 @@ export default function App() {
         await pc.setLocalDescription(offer);
         console.log('Created local offer');
 
-        const res = await fetch('https://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview', {
+        const key = import.meta.env.VITE_OAI_KEY;
+        const endpoint = import.meta.env.VITE_OAI_ENDPOINT;
+        const model = import.meta.env.VITE_OAI_MODEL;
+        const missing = [];
+        if (!key) missing.push('VITE_OAI_KEY');
+        if (!endpoint) missing.push('VITE_OAI_ENDPOINT');
+        if (!model) missing.push('VITE_OAI_MODEL');
+        if (missing.length) {
+          const msg = `Missing env vars: ${missing.join(', ')}`;
+          console.error(msg);
+          setStatus(msg);
+          return;
+        }
+
+        const res = await fetch(`${endpoint}?model=${model}`, {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${import.meta.env.VITE_OAI_KEY}`,
+            Authorization: `Bearer ${key}`,
             'Content-Type': 'application/sdp',
           },
           body: offer.sdp,


### PR DESCRIPTION
## Summary
- Replace hard-coded OpenAI endpoint/model with `VITE_OAI_ENDPOINT` and `VITE_OAI_MODEL`
- Validate required env vars before initiating realtime request
- Document new variables and provide `.env.example`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898cdff1000833082b7cccfa0aff20d