### PR TITLE
Use webrtc-adapter for WebRTC compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Demo frontend for a voice-first chat that morphs between a speaking circle and r
    npm run dev
    ```
 
+This project imports [`webrtc-adapter`](https://github.com/webrtchacks/adapter) for broader WebRTC browser compatibility. The adapter is loaded in `frontend/src/main.jsx`.
+
 The interface starts as a black‑and‑white circle that animates with the model’s voice. When the model issues a `render` message with a `ClassCardGrid`, the circle transforms into the cards and retracts once the conversation moves on.
 
 Connection status and activity logs are printed to the browser console, and a small status label shows the current WebRTC state (`connecting`, `connected`, `disconnected`, or `failed`).

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,3 +1,4 @@
+import 'webrtc-adapter';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';


### PR DESCRIPTION
## Summary
- import `webrtc-adapter` in the frontend entry to smooth out browser quirks
- document the adapter usage in the README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898ce02d4b08330bd8ba69eb1cbdff3