### PR TITLE
feat: cleanup WebRTC resources on unmount

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,17 +7,24 @@ export default function App() {
   const [speaking, setSpeaking] = useState(false);
   const [status, setStatus] = useState('connecting');
 
+  // store references for cleanup
+  const pcRef = useRef(null);
+  const dcRef = useRef(null);
+  const streamRef = useRef(null);
+
   useEffect(() => {
     async function connect() {
       console.log('Starting WebRTC connection...');
       try {
         const pc = new RTCPeerConnection();
+        pcRef.current = pc;
         pc.onconnectionstatechange = () => {
           console.log('Connection state:', pc.connectionState);
           setStatus(pc.connectionState);
         };
 
         const dc = pc.createDataChannel('oai-events');
+        dcRef.current = dc;
         dc.onopen = () => console.log('Data channel opened');
         dc.onerror = (err) => console.error('Data channel error', err);
         dc.onmessage = (e) => {
@@ -27,6 +34,7 @@ export default function App() {
         };
 
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        streamRef.current = stream;
         console.log('Got user media');
         stream.getAudioTracks().forEach((t) => pc.addTrack(t, stream));
         localRef.current.srcObject = stream;
@@ -60,6 +68,26 @@ export default function App() {
       }
     }
     connect();
+
+    return () => {
+      if (dcRef.current && dcRef.current.readyState !== 'closed') {
+        try {
+          dcRef.current.close();
+        } catch (e) {
+          console.error('Failed to close data channel', e);
+        }
+      }
+      if (pcRef.current && pcRef.current.connectionState !== 'closed') {
+        try {
+          pcRef.current.close();
+        } catch (e) {
+          console.error('Failed to close peer connection', e);
+        }
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((t) => t.stop());
+      }
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- store peer connection, data channel and media stream in refs
- add cleanup to close WebRTC connections and stop media tracks

## Testing
- `npm test`
- `node - <<'NODE'
const dc={readyState:'open',closed:false,close(){this.closed=true;this.readyState='closed';}};
const pc={connectionState:'connected',closed:false,close(){this.closed=true;this.connectionState='closed';}};
const stream={tracks:[{stopped:false,stop(){this.stopped=true;}}],getTracks(){return this.tracks;}};
const dcRef={current:dc};
const pcRef={current:pc};
const streamRef={current:stream};
(() => {
  if (dcRef.current && dcRef.current.readyState !== 'closed') {
    try { dcRef.current.close(); } catch (e) {}
  }
  if (pcRef.current && pcRef.current.connectionState !== 'closed') {
    try { pcRef.current.close(); } catch (e) {}
  }
  if (streamRef.current) {
    streamRef.current.getTracks().forEach((t) => t.stop());
  }
})();
console.log('dc closed', dc.closed, 'pc closed', pc.closed, 'track stopped', stream.tracks[0].stopped);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6898cdfdb7b88330b2576cda34afa992